### PR TITLE
Fix broken wiki/license links, change heart to character entity for compatibility.

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 	<div id="intro">
 		<nav>
 			<a href="http://gun.js.org/" target="_blank">Get Started</a>
-			<a href="https://github.com/amark/gun/wiki/JS-API" target="_blank">Documentation</a>
+			<a href="https://github.com/amark/gun/wiki/API-(v0.3.x)" target="_blank">Documentation</a>
 			<a href="http://gun.js.org/think.html">Tutorials</a>
 			<a href="https://github.com/amark/gun">Download</a>
 		</nav>
@@ -465,14 +465,14 @@
 		</div>
 		<nav>
 			<a href="http://gun.js.org/" target="_blank">Get Started</a>
-			<a href="https://github.com/amark/gun/wiki/JS-API" target="_blank">Documentation</a>
+			<a href="https://github.com/amark/gun/wiki/API-(v0.3.x)" target="_blank">Documentation</a>
 			<a href="http://gun.js.org/think.html">Tutorials</a>
 			<a href="https://github.com/amark/gun">Download</a>
 		</nav>
 	</div>
 	<footer>
 		<div class="container">
-			<p>Designed with ♥ by Mark Nadal, the gun team, and many very awesome contributors. Liberally licensed under  <a href="https://github.com/amark/gun/wiki/package.json"> Zlib or MIT or Apache 2.0.</a></p>
+			<p>Designed with &hearts; by Mark Nadal, the gun team, and many very awesome contributors. Liberally licensed under  <a href="https://github.com/amark/gun/blob/master/LICENSE.md"> Zlib or MIT or Apache 2.0.</a></p>
 		</div>
 	</footer>
 </body>


### PR DESCRIPTION
Since our wiki refactor, the `documentation` links broke. That's been updated to point to the latest version of our API docs.

The license URL was pointing to a non-existent page on the wiki, and was landing to a page that prompted the user to create a wiki entry. It's been changed to point to the gun repo instead.

The raw heart character in "Designed with <heart> by Mark..." was breaking on some browsers. I've updated it to use a character entity instead, ensuring browsers correctly interpret the input.
